### PR TITLE
Remove unused text transition rule

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -126,14 +126,3 @@ main {
     outline-offset: 3px;
 }
 
-/* Animation for text transitions */
-@keyframes fadeInOut {
-    0% { opacity: 0; }
-    20% { opacity: 1; }
-    80% { opacity: 1; }
-    100% { opacity: 0; }
-}
-
-.text-transition {
-    animation: fadeInOut 2s ease;
-}


### PR DESCRIPTION
## Summary
- remove unused `.text-transition` rule and animation from CSS

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68414a6dce28832c9602ed942d5eb179